### PR TITLE
Add log-scraping for ImqsTimeSeries and ImqsInsite services

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -26,6 +26,8 @@ func main() {
 	s.Sources = append(s.Sources, logscraper.NewLogSource("yellowfin", "c:/imqsvar/yellowfin/appserver/logs/yellowfin.log", logscraper.YellowfinLogParser))
 	s.Sources = append(s.Sources, logscraper.NewLogSource("www_server", "c:/imqsvar/logs/www-server.log", logscraper.GoLogParser))
 	s.Sources = append(s.Sources, logscraper.NewLogSource("www_js", "c:/imqsvar/logs/www-js.log", logscraper.GoLogParser))
+	s.Sources = append(s.Sources, logscraper.NewLogSource("timeseries", "c:/imqsvar/logs/imqs-timeseries.log", logscraper.GoLogParser))
+	s.Sources = append(s.Sources, logscraper.NewLogSource("insite", "c:/imqsvar/logs/insite.log", logscraper.GoLogParser))
 
 	// Comment out the following line when debugging
 	s.SendToLoggly = true


### PR DESCRIPTION
We want the log-scraper service to pick up our services' log files and send them off to [Loggly](https://www.loggly.com/). We add the references here. Because this is a nested submodule, we'll need to update reference to this repo in the parent logscraper-builder repo as well.

@wesseloosthuizen @wastrauss 
